### PR TITLE
Misc updates based on recent discussion with co-authors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ DNSOP                                                         M. Andrews
 Internet-Draft                                                       ISC
 Updates: 1034 (if approved)                                     S. Huque
 Intended status: Standards Track                              Salesforce
-Expires: 17 January 2022                                      P. Wouters
+Expires: 26 January 2022                                      P. Wouters
                                                                    Aiven
                                                               D. Wessels
                                                                 Verisign
-                                                            16 July 2021
+                                                            25 July 2021
 
 
              Glue In DNS Referral Responses Is Not Optional
@@ -21,11 +21,11 @@ Abstract
 
    The DNS uses glue records to allow iterative clients to find the
    addresses of nameservers that are contained within a delegated zone.
-   Servers are expected to return available glue records in referrals.
-   If message size constraints prevent the inclusion of all glue records
-   in a UDP response, the server MUST set the TC flag to inform the
-   client that the response is incomplete, and that the client SHOULD
-   use TCP to retrieve the full response.
+   Authoritative Servers are expected to return all available glue
+   records in referrals.  If message size constraints prevent the
+   inclusion of all glue records in a UDP response, the server MUST set
+   the TC flag to inform the client that the response is incomplete, and
+   that the client SHOULD use TCP to retrieve the full response.
 
 Status of This Memo
 
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 17 January 2022.
+   This Internet-Draft will expire on 26 January 2022.
 
 Copyright Notice
 
@@ -54,7 +54,7 @@ Copyright Notice
 
 
 
-Andrews, et al.          Expires 17 January 2022                [Page 1]
+Andrews, et al.          Expires 26 January 2022                [Page 1]
 
 Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
@@ -71,18 +71,17 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
-     1.1.  Reserved Words  . . . . . . . . . . . . . . . . . . . . .   2
-   2.  Clarifying modifications to RFC1034 . . . . . . . . . . . . .   3
-   3.  Why glue is required  . . . . . . . . . . . . . . . . . . . .   3
-     3.1.  Example one: Missing glue . . . . . . . . . . . . . . . .   3
-     3.2.  Example two: Sibling Glue from the same delegating
-           zone  . . . . . . . . . . . . . . . . . . . . . . . . . .   4
-     3.3.  Example three: Cross Zone Sibling Glue  . . . . . . . . .   5
-     3.4.  Promoted (or orphaned) glue . . . . . . . . . . . . . . .   6
-   4.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
-   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
-   6.  Normative References  . . . . . . . . . . . . . . . . . . . .   6
-   7.  Informative References  . . . . . . . . . . . . . . . . . . .   7
+     1.1.  Reserved Words  . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Glue record example . . . . . . . . . . . . . . . . . . . . .   3
+     2.1.  Missing glue  . . . . . . . . . . . . . . . . . . . . . .   3
+   3.  Updates to RFC 1034 . . . . . . . . . . . . . . . . . . . . .   4
+   4.  Sibling Glue  . . . . . . . . . . . . . . . . . . . . . . . .   5
+     4.1.  Sibling Glue example  . . . . . . . . . . . . . . . . . .   5
+   5.  Promoted (or orphaned) glue . . . . . . . . . . . . . . . . .   6
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   6
+   8.  Normative References  . . . . . . . . . . . . . . . . . . . .   6
+   9.  Informative References  . . . . . . . . . . . . . . . . . . .   6
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .   7
 
 1.  Introduction
@@ -90,13 +89,31 @@ Table of Contents
    The Domain Name System (DNS) [RFC1034], [RFC1035] uses glue records
    to allow iterative clients to find the addresses of nameservers that
    are contained within a delegated zone.  Glue records are added to the
-   parent zone as part of the delegation process.  Servers are expected
-   to return all available glue records in referrals.  If message size
-   constraints prevent the inclusion of all glue records in a UDP
-   response, the server MUST set the TC flag to inform the client that
-   the response is incomplete, and that the client SHOULD use TCP to
-   retrieve the full response.  This document clarifies that
-   expectation.
+   parent zone as part of the delegation process and returned in
+   referral responses, otherwise a resolver following the referral has
+   no way of finding these addresses.  Authoritative servers are
+   expected to return all available glue records in referrals.  If
+   message size constraints prevent the inclusion of all glue records in
+   a UDP response, the server MUST set the TC (Truncated) flag to inform
+   the client that the response is incomplete, and that the client
+   SHOULD use TCP to retrieve the full response.  This document
+   clarifies that expectation.
+
+   DNS responses sometimes contain optional data in the additional
+   section.  Glue records however are not optional.  Several other
+   protocol extensions, when used, are also not optional.  This includes
+   TSIG [RFC2845], OPT [RFC6891], and SIG(0) [RFC2931].
+
+
+
+
+
+
+
+Andrews, et al.          Expires 26 January 2022                [Page 2]
+
+Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
+
 
 1.1.  Reserved Words
 
@@ -104,44 +121,38 @@ Table of Contents
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
    document are to be interpreted as described in [RFC2119].
 
+2.  Glue record example
 
+   The following is a simple example of glue records present in the
+   delegating zone "test" for the child zone "foo.test".  The
+   nameservers for foo.test (ns1.foo.test and ns2.foo.test) are both
+   below the delegation point.  They are configured as glue records in
+   the "test" zone:
 
+         foo.test.                  86400   IN NS      ns1.foo.test.
+         foo.test.                  86400   IN NS      ns2.foo.test.
+         ns1.foo.test.              86400   IN A       192.0.1.1
+         ns2.foo.test.              86400   IN A       192.0.1.2
 
+   Referral responses from "test" for "foo.test" must include the glue
+   records in the additional section (and set TC=1 if they do not fit):
 
+      ;; QUESTION SECTION:
+      ;www.foo.test.       IN      A
 
+      ;; AUTHORITY SECTION:
+      foo.test.               86400        IN      NS      ns1.bar.test.
+      foo.test.               86400        IN      NS      ns2.bar.test.
 
-Andrews, et al.          Expires 17 January 2022                [Page 2]
-
-Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
+      ;; ADDITIONAL SECTION:
+      ns1.foo.test.           86400        IN      A       192.0.1.1
+      ns2.foo.test.           86400        IN      A       192.0.1.2
 
-
-2.  Clarifying modifications to RFC1034
-
-   Replace
-
-   "Copy the NS RRs for the subzone into the authority section of the
-   reply.  Put whatever addresses are available into the additional
-   section, using glue RRs if the addresses are not available from
-   authoritative data or the cache.  Go to step 4."
-
-   with
-
-   "Copy the NS RRs for the subzone into the authority section of the
-   reply.  Put whatever addresses are available into the additional
-   section, using glue RRs if the addresses are not available from
-   authoritative data or the cache.  If all glue RRs do not fit, set
-   TC=1 in the header.  Go to step 4."
-
-3.  Why glue is required
+2.1.  Missing glue
 
    While not common, real life examples of servers that fail to set TC=1
-   when glue records are available exist and they do cause resolution
+   when glue records are available, exist and they do cause resolution
    failures.
-
-   _COMMENT DW 20210715: The above doesn't explain why glue is required.
-   Rather it explains why this doc is being written._
-
-3.1.  Example one: Missing glue
 
    The example below from June 2020 shows a case where none of the glue
    records, present in the zone, fitted into the available space and
@@ -155,18 +166,7 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-Andrews, et al.          Expires 17 January 2022                [Page 3]
+Andrews, et al.          Expires 26 January 2022                [Page 3]
 
 Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
@@ -198,42 +198,56 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
       dhhs.gov.               3600    IN DS      635 8 1 ...
       dhhs.gov.               3600    IN RRSIG   DS 8 2 3600 ...
 
-      ;; Query time: 226 msec
-      ;; SERVER: 69.36.157.30#53(69.36.157.30)
-      ;; WHEN: Wed Apr 15 13:34:43 AEST 2020
-      ;; MSG SIZE  rcvd: 500
+3.  Updates to RFC 1034
 
-      %
+   Replace
 
-   DNS responses sometimes contain optional data in the additional
-   section.  Glue records however are not optional.  Several other
-   protocol extensions, when used, are also not optional.  This includes
-   TSIG [RFC2845], OPT [RFC6891], and SIG(0) [RFC2931].
+   "Copy the NS RRs for the subzone into the authority section of the
+   reply.  Put whatever addresses are available into the additional
+   section, using glue RRs if the addresses are not available from
+   authoritative data or the cache.  Go to step 4."
 
-3.2.  Example two: Sibling Glue from the same delegating zone
+   with
 
-   Sibling glue are glue records that are not contained in the
-   delegating zone itself, but in another delegated zone.  In many
-   cases, these are not strictly required for resolution, since the
-   resolver can make follow-on queries to the same zone to resolve the
-   nameserver addresses after following the referral to the sibling
-   zone.  However, most nameserver implementations provide them as an
-   optimization to obviate the need for extra traffic.
+   "Copy the NS RRs for the subzone into the authority section of the
+   reply.  Put whatever addresses are available into the additional
+   section, using glue RRs if the addresses are not available from
+   authoritative data or the cache.  If all glue RRs do not fit, set
+   TC=1 in the header.  Go to step 4."
 
 
 
-Andrews, et al.          Expires 17 January 2022                [Page 4]
+
+
+
+
+
+Andrews, et al.          Expires 26 January 2022                [Page 4]
 
 Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
 
-   _COMMENT DW 20210715: This example would be better if it showed a
-   cyclic dependency.  As is the foo.test domain can be resolved because
-   bar.test doesn't have any other dependencies._
+4.  Sibling Glue
+
+   Sibling glue are glue records that are not contained in the delegated
+   zone itself, but in another delegated zone from the same parent.  In
+   many cases, these are not strictly required for resolution, since the
+   resolver can make follow-on queries to the same zone to resolve the
+   nameserver addresses after following the referral to the sibling
+   zone.  However, most nameserver implementations today provide them as
+   an optimization to obviate the need for extra traffic from iterative
+   resolvers.
+
+   This document clarifies that sibling glue (being part of all
+   available glue records) MUST be returned in referral responses, and
+   that the requirement to set TC=1 applies to sibling glue that cannot
+   fit in the response too.
+
+4.1.  Sibling Glue example
 
    Here the delegating zone "test" contains 2 delegations for the
-   subzones "bar.test" and "foo.test". The nameservers for "foo.test"
-   consist of sibling glue for "bar.test" (ns1.bar.test and ns2.bar.test).
+   subzones "bar.test" and "foo.test".  The nameservers for "foo.test"
+   require sibling glue from "bar.test" (ns1.bar.test and ns2.bar.test).
 
          bar.test.                  86400   IN NS      ns1.bar.test.
          bar.test.                  86400   IN NS      ns2.bar.test.
@@ -243,8 +257,8 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
          foo.test.                  86400   IN NS      ns1.bar.test.
          foo.test.                  86400   IN NS      ns2.bar.test.
 
-   Referral responses from test for foo.test should include the sibling
-   glue:
+   Referral responses from "test" for "foo.test" must include the
+   sibling glue (and set TC=1 if they do not fit):
 
       ;; QUESTION SECTION:
       ;www.foo.test.       IN      A
@@ -257,20 +271,6 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
       ns1.bar.test.           86400        IN      A       192.0.1.1
       ns2.bar.test.           86400        IN      A       192.0.1.2
 
-   Question: if sibling glue from the same delegating zone does not fit
-   into the response, should we also recommend or require that TC=1 be
-   set?
-
-   _COMMENT DW 20210715: From today's call I believe we agreed that all
-   sibling glue must be included or set TC=1._
-
-3.3.  Example three: Cross Zone Sibling Glue
-
-   Here is a more complex example of sibling glue that lives in another
-   zone, but is required to resolve a circular dependency in the zone
-   configuration.
-
-   _COMMENT DW 20210715: IMO this section/example should be removed._
 
 
 
@@ -278,46 +278,31 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
 
 
-Andrews, et al.          Expires 17 January 2022                [Page 5]
+Andrews, et al.          Expires 26 January 2022                [Page 5]
 
 Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
 
-      example.com.               86400   IN NS      ns1.example.net.
-      example.com.               86400   IN NS      ns2.example.net.
-      ns1.example.com.           86400   IN A       192.0.1.1
-      ns2.example.com.           86400   IN A       192.0.1.2
-
-      example.net.               86400   IN NS      ns1.example.com.
-      example.net.               86400   IN NS      ns2.example.com.
-      ns1.example.net.           86400   IN A       198.51.100.1
-      ns2.example.net.           86400   IN A       198.51.100.2
-
-3.4.  Promoted (or orphaned) glue
+5.  Promoted (or orphaned) glue
 
    When a zone is deleted but the parent notices that its NS glue
    records are required for other zones, it MAY opt to take these (now
    orphaned) glue records into its own zone to ensure that other zones
-   depending on this glue are not broken.  Technically, these NS records
-   are no longer glue records, but authoritative data of the parent
-   zone, and should be added to the DNS response similarly to regular
-   glue records.
+   depending on this glue are not broken.  Technically, these address
+   records are no longer glue records, but authoritative data of the
+   parent zone, and should be added to the DNS response similarly to
+   regular glue records.
 
-4.  Security Considerations
+6.  Security Considerations
 
    This document clarifies correct DNS server behaviour and does not
    introduce any changes or new security considerations.
 
-   _COMMENT DW 20210715: I think the document should say that some
-   servers might experience an increase in TCP if implementations
-   require all glue or set TC=1.  If not in this section then somewhere
-   else._
-
-5.  IANA Considerations
+7.  IANA Considerations
 
    There are no actions for IANA.
 
-6.  Normative References
+8.  Normative References
 
    [RFC1034]  Mockapetris, P., "Domain names - concepts and facilities",
               STD 13, RFC 1034, DOI 10.17487/RFC1034, November 1987,
@@ -332,14 +317,7 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
               DOI 10.17487/RFC2119, March 1997,
               <https://www.rfc-editor.org/info/rfc2119>.
 
-
-
-Andrews, et al.          Expires 17 January 2022                [Page 6]
-
-Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
-
-
-7.  Informative References
+9.  Informative References
 
    [RFC2845]  Vixie, P., Gudmundsson, O., Eastlake 3rd, D., and B.
               Wellington, "Secret Key Transaction Authentication for DNS
@@ -349,6 +327,17 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
    [RFC2931]  Eastlake 3rd, D., "DNS Request and Transaction Signatures
               ( SIG(0)s )", RFC 2931, DOI 10.17487/RFC2931, September
               2000, <https://www.rfc-editor.org/info/rfc2931>.
+
+
+
+
+
+
+
+Andrews, et al.          Expires 26 January 2022                [Page 6]
+
+Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
+
 
    [RFC4033]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
               Rose, "DNS Security Introduction and Requirements",
@@ -387,14 +376,6 @@ Authors' Addresses
    Paul Wouters
    Aiven
 
-
-
-
-Andrews, et al.          Expires 17 January 2022                [Page 7]
-
-Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
-
-
    Email: paul.wouters@aiven.io
 
 
@@ -409,42 +390,5 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Andrews, et al.          Expires 17 January 2022                [Page 8]
+Andrews, et al.          Expires 26 January 2022                [Page 7]
 ```

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
       ;www.foo.test.       IN      A
 
       ;; AUTHORITY SECTION:
-      foo.test.               86400        IN      NS      ns1.bar.test.
-      foo.test.               86400        IN      NS      ns2.bar.test.
+      foo.test.               86400        IN      NS      ns1.foo.test.
+      foo.test.               86400        IN      NS      ns2.foo.test.
 
       ;; ADDITIONAL SECTION:
       ns1.foo.test.           86400        IN      A       192.0.1.1

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ DNSOP                                                         M. Andrews
 Internet-Draft                                                       ISC
 Updates: 1034 (if approved)                                     S. Huque
 Intended status: Standards Track                              Salesforce
-Expires: 26 January 2022                                      P. Wouters
+Expires: 27 January 2022                                      P. Wouters
                                                                    Aiven
                                                               D. Wessels
                                                                 Verisign
-                                                            25 July 2021
+                                                            26 July 2021
 
 
              Glue In DNS Referral Responses Is Not Optional
@@ -42,7 +42,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 26 January 2022.
+   This Internet-Draft will expire on 27 January 2022.
 
 Copyright Notice
 
@@ -54,7 +54,7 @@ Copyright Notice
 
 
 
-Andrews, et al.          Expires 26 January 2022                [Page 1]
+Andrews, et al.          Expires 27 January 2022                [Page 1]
 
 Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
@@ -110,7 +110,7 @@ Table of Contents
 
 
 
-Andrews, et al.          Expires 26 January 2022                [Page 2]
+Andrews, et al.          Expires 27 January 2022                [Page 2]
 
 Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
@@ -166,7 +166,7 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
 
 
-Andrews, et al.          Expires 26 January 2022                [Page 3]
+Andrews, et al.          Expires 27 January 2022                [Page 3]
 
 Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
@@ -222,7 +222,7 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
 
 
-Andrews, et al.          Expires 26 January 2022                [Page 4]
+Andrews, et al.          Expires 27 January 2022                [Page 4]
 
 Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
@@ -245,9 +245,8 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
 4.1.  Sibling Glue example
 
-   Here the delegating zone "test" contains 2 delegations for the
-   subzones "bar.test" and "foo.test".  The nameservers for "foo.test"
-   require sibling glue from "bar.test" (ns1.bar.test and ns2.bar.test).
+   Here the delegating zone "test" contains 2 sub-delegations for the
+   subzones "bar.test" and "foo.test".
 
          bar.test.                  86400   IN NS      ns1.bar.test.
          bar.test.                  86400   IN NS      ns2.bar.test.
@@ -278,7 +277,8 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
 
 
-Andrews, et al.          Expires 26 January 2022                [Page 5]
+
+Andrews, et al.          Expires 27 January 2022                [Page 5]
 
 Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
@@ -334,7 +334,7 @@ Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
 
 
-Andrews, et al.          Expires 26 January 2022                [Page 6]
+Andrews, et al.          Expires 27 January 2022                [Page 6]
 
 Internet-DrafGlue In DNS Referral Responses Is Not Optional    July 2021
 
@@ -390,5 +390,5 @@ Authors' Addresses
 
 
 
-Andrews, et al.          Expires 26 January 2022                [Page 7]
+Andrews, et al.          Expires 27 January 2022                [Page 7]
 ```

--- a/draft-ietf-dnsop-glue-is-not-optional.md
+++ b/draft-ietf-dnsop-glue-is-not-optional.md
@@ -129,8 +129,8 @@ in the additional section (and set TC=1 if they do not fit):
    ;www.foo.test.  	IN	A
 
    ;; AUTHORITY SECTION:
-   foo.test.               86400	IN	NS	ns1.bar.test.
-   foo.test.               86400	IN	NS	ns2.bar.test.
+   foo.test.               86400	IN	NS	ns1.foo.test.
+   foo.test.               86400	IN	NS	ns2.foo.test.
 
    ;; ADDITIONAL SECTION:
    ns1.foo.test.           86400	IN	A	192.0.1.1

--- a/draft-ietf-dnsop-glue-is-not-optional.md
+++ b/draft-ietf-dnsop-glue-is-not-optional.md
@@ -215,9 +215,8 @@ in the additional section (and set TC=1 if they do not fit):
 
 ## Sibling Glue example
 
-Here the delegating zone "test" contains 2 delegations for the
-subzones "bar.test" and "foo.test". The nameservers for "foo.test"
-require sibling glue from "bar.test" (ns1.bar.test and ns2.bar.test).
+Here the delegating zone "test" contains 2 sub-delegations for the
+subzones "bar.test" and "foo.test".
 
 ~~~
       bar.test.                  86400   IN NS      ns1.bar.test.


### PR DESCRIPTION
Misc updates ..

Rework Sibling Glue section, and clarify that they MUST be included, and also subject to TC=1 if they don't fit.

Remove the cross parent zone cyclic dependency example, which doesn't work (I think we agreed to that, but I can be persuaded to add it back, if we want to point out a misconfiguration as a warning).

Move the paragraph about non-optionality of types of additional section data into the tail end of the Intro. It deserves to be more prominently mentioned than buried at the end of the example of missing glue.

Addressed Duane's comment that the "Why is Glue Required?" section did not actually say why, but instead just gave examples. Instead, I added a one phrase explaining why to the Intro section that defines glue records. I don't think it requires a separate section.

Removed Duane's comment about "I think the document should say that some servers might experience an increase in TCP if implementations require all glue or set TC=1.  If not in this section then somewhere else._". I agree we should address this, so I've made an "issue" for it. And we can add the relevant text in the next update, once we figure out where it goes (an "Operational Considerations" section perhaps?).


